### PR TITLE
Sort result by phenomenon time 

### DIFF
--- a/connected-systems-api/provider/part2/formats/om_json_scalar.py
+++ b/connected-systems-api/provider/part2/formats/om_json_scalar.py
@@ -9,19 +9,28 @@ from ..util import SchemaParser, Observation
 class OMJsonSchemaParser(SchemaParser):
 
     def decode(self, data: any) -> Observation:
-        return Observation(
+        obs = Observation(
             datastream_id=data["datastream"],
             resultTime=DateTime.fromisoformat(data["resultTime"]),
             result=orjson.dumps(data["result"]),
         )
+        #if not provided phenomenon time equals result time by default
+        obs.phenomenonTime = DateTime.fromisoformat(data["phenomenonTime"]) if "phenomenonTime" in data else obs.resultTime
+
+        return obs
 
     def encode(self, obs: asyncpg.Record) -> any:
         # TODO(specki): Check what is officially required here, e.g. are datastream@link or foi@link necessary?
 
         # unpack always returns tuple for consistency
-        return {
+        obs_json =  {
             "id": str(obs["uuid"]),
             "datastream@id": str(obs["datastream_id"]),
             "resultTime": obs["resulttime"],
             "result": orjson.loads(obs["result"])
         }
+
+        if obs["phenomenontime"] is not None:
+            obs_json["phenomenonTime"] = obs["phenomenontime"]
+
+        return obs_json

--- a/connected-systems-api/provider/part2/part2.py
+++ b/connected-systems-api/provider/part2/part2.py
@@ -10,7 +10,7 @@ from elasticsearch.dsl import async_connections
 from pygeoapi.provider.base import ProviderGenericError, ProviderItemNotFoundError, ProviderInvalidQueryError
 
 from .formats.om_json_scalar import OMJsonSchemaParser
-from .util import TimescaleDbConfig, ObservationQuery, Observation
+from .util import TimescaleDbConfig, ObservationQuery, Observation, SORT_ORDER, ORDER_BY
 from .. import es_conn_part2
 from ..datastream import Datastream
 from ..definitions import *
@@ -420,6 +420,9 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
         q = ObservationQuery()
         q.with_limit(parameters.limit)
 
+        #default order by result time
+        q.with_sort(order=SORT_ORDER.ASCENDING, order_by= ORDER_BY.RESULTTIME)
+
         if parameters.id:
             q.with_id(parameters.id)
         if parameters.offset:
@@ -431,10 +434,15 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
         if parameters.datastream:
             q.with_datastream(parameters.datastream)
 
+        #only if filtered by phenomenon time (and no result time filter) order by phenomenon time
+        if parameters._phenomenonTime and not parameters._resultTime:
+            q.with_sort(order=SORT_ORDER.ASCENDING, order_by=ORDER_BY.PHENOMENONTIME)
+
         async with self._pool.acquire() as connection:
             LOGGER.debug("SELECT * FROM observations " + q.to_sql())
             LOGGER.debug(f"{q.parameters}")
-            return await connection.fetch("SELECT * FROM observations " + q.to_sql(), *q.parameters)
+            query = "SELECT * FROM observations " + q.to_sql()
+            return await connection.fetch(query, *q.parameters)
 
     async def _delete_observation(self, identifier: str):
         q = ObservationQuery()

--- a/connected-systems-api/provider/part2/part2.py
+++ b/connected-systems-api/provider/part2/part2.py
@@ -139,7 +139,7 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
                                    UPDATE datastreams SET
                                    resulttime_start=LEAST(resulttime_start, NEW.resulttime),
                                    resulttime_end=GREATEST(resulttime_start, NEW.resulttime),
-                                   phenomenontime_start=GREATEST(phenomenontime_start, NEW.phenomenontime),
+                                   phenomenontime_start=LEAST(phenomenontime_start, NEW.phenomenontime),
                                    phenomenontime_end=GREATEST(phenomenontime_start, NEW.phenomenontime)
                                    WHERE id=NEW.datastream_id;
                                    RETURN NULL;

--- a/connected-systems-api/provider/part2/part2.py
+++ b/connected-systems-api/provider/part2/part2.py
@@ -419,9 +419,7 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
     async def _get_observations(self, parameters: ObservationsParams) -> list:
         q = ObservationQuery()
         q.with_limit(parameters.limit)
-
-        #default order by result time
-        q.with_sort(order=SORT_ORDER.ASCENDING, order_by= ORDER_BY.RESULTTIME)
+        q.with_sort(order=SORT_ORDER.ASCENDING, order_by= ORDER_BY.PHENOMENONTIME) #always sorted by phenomenon time
 
         if parameters.id:
             q.with_id(parameters.id)
@@ -434,9 +432,6 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
         if parameters.datastream:
             q.with_datastream(parameters.datastream)
 
-        #only if filtered by phenomenon time (and no result time filter) order by phenomenon time
-        if parameters._phenomenonTime and not parameters._resultTime:
-            q.with_sort(order=SORT_ORDER.ASCENDING, order_by=ORDER_BY.PHENOMENONTIME)
 
         async with self._pool.acquire() as connection:
             LOGGER.debug("SELECT * FROM observations " + q.to_sql())

--- a/connected-systems-api/provider/part2/util.py
+++ b/connected-systems-api/provider/part2/util.py
@@ -36,7 +36,15 @@ class TimescaleDbConfig:
 
     def connection_string(self) -> str:
         return f"postgres://{self.user}:{self.password}@{self.hostname}:{self.port}/{self.dbname}"
+    
 
+class SORT_ORDER(Enum):
+    DESCENDING = "DESC"
+    ASCENDING = "ASC"
+
+class ORDER_BY(Enum):
+    RESULTTIME = "resulttime"
+    PHENOMENONTIME = "phenomenontime"
 
 class SchemaParser:
     """
@@ -64,6 +72,8 @@ class ObservationQuery:
         self.parameters = []
         self.limit = 10
         self.offset = 0
+        self.order = "ASC"
+        self.order_by = "resulttime"
 
     def with_id(self, ids: List[str]) -> Self:
         return self._in("uuid", ids)
@@ -100,7 +110,21 @@ class ObservationQuery:
         if time[1] is not None:
             self.clauses.append(f"{key}<=${len(self.clauses) + 1}")
             self.parameters.append(time[1])
+
         return self
+    
+    def with_sort(self, order: SORT_ORDER, order_by: ORDER_BY):
+        if order == SORT_ORDER.ASCENDING:
+            self.order = "ASC"
+        else:
+            self.order = "DESC"
+        
+        if order_by == ORDER_BY.RESULTTIME:
+            self.order_by = "resulttime"
+        else:
+            self.order_by = "phenomenontime"
+
+        
 
     def to_sql(self, with_paging: bool = True) -> str:
         stub = ""
@@ -109,6 +133,9 @@ class ObservationQuery:
             # first clause
             stub = "WHERE "
             stub += " AND ".join(self.clauses)
+
+        if self.order and self.order_by:
+            stub += f" ORDER BY {self.order_by} {self.order}"
 
         if with_paging:
             stub += f" LIMIT {self.limit}"


### PR DESCRIPTION
- ensures result of queries for observations are sorted by phenomenon time (ASC)
  - adds `ORDER BY phenomenontime ASC` clause to the SQL query  
- adds phenomenon time to the observations
  - by default phenomenon time equals result time 
  
  fixes #17 