### PR TITLE
Fix: Sort observations by resultTime in descending order

### DIFF
--- a/connected-systems-api/provider/part2/util.py
+++ b/connected-systems-api/provider/part2/util.py
@@ -110,6 +110,9 @@ class ObservationQuery:
             stub = "WHERE "
             stub += " AND ".join(self.clauses)
 
+        # Sort observations by resultTime in descending order (newest first)
+        stub += " ORDER BY resulttime DESC"
+
         if with_paging:
             stub += f" LIMIT {self.limit}"
             if self.offset > 0:


### PR DESCRIPTION
Fixes #5

## Changes Made
Added `ORDER BY resulttime DESC` clause to the SQL query in the `ObservationQuery.to_sql()` method ([util.py](connected-systems-api/provider/part2/util.py#L113-L114)).

This ensures observations are returned in descending order by `resultTime`, with the newest observations appearing first.

## Why This Approach
- The sorting is applied at the database level (TimescaleDB/PostgreSQL) for optimal performance
- Using `resultTime` as the sort key aligns with the observation data model
- Descending order (newest first) is the most common use case for time-series data
- The `ORDER BY` clause is placed before `LIMIT`/`OFFSET` to ensure proper pagination


Resolves #5