### PR TITLE
Fix invalid shapely version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,10 @@ dependencies = [
     "requests>=2.32.5",
     "rtree>=1.4.1",
     "setuptools>=80.9.0",
-    "shapely==2.0.6",
     "tqdm>=4.67.1",
     "urllib3>=2.5.0",
     "numpy==2.2.4",
-    "shapely==2.6.0"
+    "shapely>=2.0.6"
 ]
 
 [tool.uv.sources]
@@ -38,7 +37,7 @@ pygeoapi = { git = "https://github.com/52north/pygeoapi.git", rev = "ec1eb38d9a6
 
 
 [tool.uv]
-build-constraint-dependencies = ["numpy==2.2.4", "shapely==2.6.0"]
+build-constraint-dependencies = ["numpy==2.2.4", "shapely>=2.0.6"]
 
 override-dependencies = [
     "numpy; sys_platform == 'never'",


### PR DESCRIPTION
## Problem

Currently `pyproject.toml` contains:

```
shapely==2.6.0
```

However, **`2.6.0` is not a published version of shapely**, which causes dependency resolution failures when running:

```
uv sync
```

Example error:

```
No version found for shapely==2.6.0
```

This issue is not visible in the Docker environment because the Docker image installs shapely via the Alpine package manager:

```
apk add py3-shapely
```

Additionally, the project uses:

```
override-dependencies = [
  "shapely; sys_platform == 'never'"
]
```

which instructs `uv` to skip installing shapely via pip.

As a result:

* Docker builds succeed
* Local development environments fail when resolving dependencies

## Solution

This PR changes the dependency to:

```
shapely>=2.0.6
```

This ensures:

* a valid minimum version
* compatibility with future shapely releases
* correct dependency resolution for local environments