### PR TITLE
Proposal: Store Observation Results as JSONB in TimescaleDB

### DIFF
--- a/connected-systems-api/provider/part2/formats/om_json_scalar.py
+++ b/connected-systems-api/provider/part2/formats/om_json_scalar.py
@@ -12,7 +12,7 @@ class OMJsonSchemaParser(SchemaParser):
         return Observation(
             datastream_id=data["datastream"],
             resultTime=DateTime.fromisoformat(data["resultTime"]),
-            result=orjson.dumps(data["result"]),
+            result=orjson.dumps(data["result"]).decode("utf-8"),
         )
 
     def encode(self, obs: asyncpg.Record) -> any:

--- a/connected-systems-api/provider/part2/part2.py
+++ b/connected-systems-api/provider/part2/part2.py
@@ -109,7 +109,7 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
                                                                 resulttime TIMESTAMPTZ NOT NULL,
                                                                 phenomenontime TIMESTAMPTZ,
                                                                 datastream_id text NOT NULL,
-                                                                result BYTEA NOT NULL,
+                                                                result JSONB NOT NULL,
                                                                 sampling_feature_id text,
                                                                 procedure_link text,
                                                                 parameters text

--- a/connected-systems-api/provider/part2/util.py
+++ b/connected-systems-api/provider/part2/util.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import field
-from typing import Self
+from typing import Self, Dict, List, Optional
 
 from ..definitions import *
 
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 class Observation:
     datastream_id: str  # id of the associated datastream
     resultTime: DateTime
-    result: bytes  # raw result data
+    result: Dict[str, any]  # raw result data
 
     id: Optional[str] = None  # unique identifier
     sampling_feature_id: Optional[str] = None


### PR DESCRIPTION
Changed type of column `result` in table `Observations` from `BYTEA` to `JSONB`.

(Currently, ) Observations are always encoded as JSON.
Semi-structured JSONB (instead of Bytea) allows for querying and aggregations of results.