### PR TITLE
Fix SQL query bugs, temporal filters and misc provider issues

### DIFF
--- a/connected-systems-api/api.py
+++ b/connected-systems-api/api.py
@@ -152,7 +152,7 @@ class CSAPI(CSMeta):
                 self.provider_part2 = load_plugin('provider', provider_definition)
 
                 if api_part2.get("strict_validation", None) is not None:
-                    self.strict_validation1 = bool(api_part2["strict_validation"])
+                    self.strict_validation2 = bool(api_part2["strict_validation"])
 
                 if self.config.get('resources') is None:
                     self.config['resources'] = {}
@@ -441,7 +441,7 @@ class CSAPI(CSMeta):
             try:
                 self.validator.validate(collection, encoding, entity)
             except jsonschema.exceptions.ValidationError as ex:
-                print(ex)
+                LOGGER.debug(ex)
                 return self.get_exception(
                     HTTPStatus.BAD_REQUEST,
                     headers,

--- a/connected-systems-api/provider/collection.py
+++ b/connected-systems-api/provider/collection.py
@@ -21,5 +21,4 @@ class Collection(AsyncDocument):
 
         self.json = raw
 
-        print(self)
         return await super().save(**kwargs)

--- a/connected-systems-api/provider/deployment.py
+++ b/connected-systems-api/provider/deployment.py
@@ -72,7 +72,7 @@ class Deployment(CSDocument):
 
 def deployment_to_geojson(deployment: Dict) -> DeploymentGeoJson:
     # Trancoding according to 23-001r0 Section 19.2.x
-    links = deployment.get(f"links") if not None else []
+    links = deployment.get("links") or []
     return DeploymentGeoJson(**{
         "type": "Feature",
         "id": deployment.get("id"),

--- a/connected-systems-api/provider/elasticsearch.py
+++ b/connected-systems-api/provider/elasticsearch.py
@@ -54,21 +54,21 @@ def parse_spatial_params(query: AsyncSearch,
 def parse_temporal_filters(query: AsyncSearch, parameters: ObservationsParams | DatastreamsParams) -> AsyncSearch:
     # Parse resultTime filter
     if parameters.resulttime_start() and parameters.resulttime_end():
-        query = query.filter("range", validTime={"gte": parameters.resulttime_start().isoformat(),
-                                                 "lte": parameters.resulttime_end().isoformat()})
-    if parameters.resulttime_start():
-        query = query.filter("range", validTime={"gte": parameters.resulttime_start().isoformat()})
-    if parameters.resulttime_end():
-        query = query.filter("range", validTime={"lte": parameters.resulttime_end().isoformat()})
+        query = query.filter("range", resultTime={"gte": parameters.resulttime_start().isoformat(),
+                                                  "lte": parameters.resulttime_end().isoformat()})
+    elif parameters.resulttime_start():
+        query = query.filter("range", resultTime={"gte": parameters.resulttime_start().isoformat()})
+    elif parameters.resulttime_end():
+        query = query.filter("range", resultTime={"lte": parameters.resulttime_end().isoformat()})
 
     # Parse phenomenonTime filter
     if parameters.phenomenontime_start() and parameters.phenomenontime_end():
-        query = query.filter("range", validTime={"gte": parameters.phenomenontime_start().isoformat(),
-                                                 "lte": parameters.phenomenontime_end().isoformat()})
-    if parameters.phenomenontime_start():
-        query = query.filter("range", validTime={"gte": parameters.phenomenontime_start().isoformat()})
-    if parameters.phenomenontime_end():
-        query = query.filter("range", validTime={"lte": parameters.phenomenontime_end().isoformat()})
+        query = query.filter("range", phenomenonTime={"gte": parameters.phenomenontime_start().isoformat(),
+                                                      "lte": parameters.phenomenontime_end().isoformat()})
+    elif parameters.phenomenontime_start():
+        query = query.filter("range", phenomenonTime={"gte": parameters.phenomenontime_start().isoformat()})
+    elif parameters.phenomenontime_end():
+        query = query.filter("range", phenomenonTime={"lte": parameters.phenomenontime_end().isoformat()})
 
     return query
 
@@ -114,9 +114,10 @@ class ElasticsearchConnector:
             raise ProviderConnectionError(msg)
 
     async def _exists(self, query: AsyncSearch) -> bool:
-        LOGGER.error(json.dumps(query.to_dict(), indent=True, default=str))
-        LOGGER.error(await query.count())
-        return (await query.count()) > 0
+        LOGGER.debug(json.dumps(query.to_dict(), indent=True, default=str))
+        count = await query.count()
+        LOGGER.debug(count)
+        return count > 0
 
     async def search(self,
                      query: AsyncSearch,
@@ -134,7 +135,7 @@ class ElasticsearchConnector:
                     "href": parameters.nextlink()
                 })
 
-            LOGGER.error("Add alternative encodings as links here!")
+            LOGGER.debug("Add alternative encodings as links here!")
 
             try:
                 return [getattr(x._source, parameters.format).to_dict() for x in found.hits], links

--- a/connected-systems-api/provider/part1/part1.py
+++ b/connected-systems-api/provider/part1/part1.py
@@ -456,8 +456,10 @@ class ConnectedSystemsESProvider(ConnectedSystemsPart1Provider, ElasticsearchCon
                     if not cascade:
                         # /req/create-replace-delete/system
                         # reject if there are nested resources: subsystems, sampling features, datastreams, control streams
-                        error_msg = f"cannot delete system with nested resources and cascade=false. "
-                        f"ref: /req/create-replace-delete/system"
+                        error_msg = (
+                            "cannot delete system with nested resources and cascade=false. "
+                            "ref: /req/create-replace-delete/system"
+                        )
 
                         # TODO: Should we run all these checks in parallel or is it more efficient to sync + exit early?
                         # check subsystems
@@ -498,10 +500,10 @@ class ConnectedSystemsESProvider(ConnectedSystemsPart1Provider, ElasticsearchCon
                                            .scan())
                             async for d in deployments:
                                 # remove link to system from deployment
-                                print(d)
+                                LOGGER.debug(d)
 
                         # await self._delete(self.systems_index_name, identifier)
-                        return ProviderGenericError("cascade=true is not implemented yet!")
+                        raise ProviderGenericError("cascade=true is not implemented yet!")
                     entity = await System.get(identifier)
                     return await entity.delete()
                 case EntityType.DEPLOYMENTS:

--- a/connected-systems-api/provider/part2/part2.py
+++ b/connected-systems-api/provider/part2/part2.py
@@ -44,9 +44,9 @@ class Cache:
 
     def remove(self, identifier: str):
         """removes element with given identifier from the list. Does not change the pointer"""
-        for elem in self.__cache:
+        for i, elem in enumerate(self.__cache):
             if elem == identifier:
-                del elem
+                self.__cache[i] = ""
 
 
 class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, ElasticsearchConnector):
@@ -138,9 +138,9 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
                                 $$BEGIN
                                    UPDATE datastreams SET
                                    resulttime_start=LEAST(resulttime_start, NEW.resulttime),
-                                   resulttime_end=GREATEST(resulttime_start, NEW.resulttime),
-                                   phenomenontime_start=GREATEST(phenomenontime_start, NEW.phenomenontime),
-                                   phenomenontime_end=GREATEST(phenomenontime_start, NEW.phenomenontime)
+                                   resulttime_end=GREATEST(resulttime_end, NEW.resulttime),
+                                   phenomenontime_start=LEAST(phenomenontime_start, NEW.phenomenontime),
+                                   phenomenontime_end=GREATEST(phenomenontime_end, NEW.phenomenontime)
                                    WHERE id=NEW.datastream_id;
                                    RETURN NULL;
                                 END;$$;
@@ -194,7 +194,7 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
                 item["id"] = identifier
             else:
                 if await Datastream().exists(id=item["id"]):
-                    raise ProviderItemNotFoundError(user_msg=f"entity with id {item['id']} already exists!")
+                    raise ProviderInvalidQueryError(user_msg=f"entity with id {item['id']} already exists!")
                 else:
                     identifier = item["id"]
 

--- a/connected-systems-api/provider/part2/util.py
+++ b/connected-systems-api/provider/part2/util.py
@@ -95,10 +95,10 @@ class ObservationQuery:
             return self
 
         if time[0] is not None:
-            self.clauses.append(f"{key}>=${len(self.clauses) + 1}")
+            self.clauses.append(f"{key} >= ${len(self.clauses) + 1}")
             self.parameters.append(time[0])
         if time[1] is not None:
-            self.clauses.append(f"{key}<=${len(self.clauses) + 1}")
+            self.clauses.append(f"{key} <= ${len(self.clauses) + 1}")
             self.parameters.append(time[1])
         return self
 
@@ -109,6 +109,8 @@ class ObservationQuery:
             # first clause
             stub = "WHERE "
             stub += " AND ".join(self.clauses)
+
+        stub += " ORDER BY resulttime ASC"
 
         if with_paging:
             stub += f" LIMIT {self.limit}"

--- a/connected-systems-api/provider/procedure.py
+++ b/connected-systems-api/provider/procedure.py
@@ -53,7 +53,7 @@ class Procedure(CSDocument):
 
 def procedure_to_geojson(procedure: Dict) -> ProcedureGeoJson:
     # Trancoding according to 23-001r0 Section 19.2.x
-    links = procedure.get(f"links") if not None else []
+    links = procedure.get("links") or []
     return ProcedureGeoJson(**{
         "type": "Feature",
         "id": procedure.get("id"),

--- a/connected-systems-api/provider/system.py
+++ b/connected-systems-api/provider/system.py
@@ -92,7 +92,7 @@ def system_to_sml(system: Dict) -> SystemSML:
 
 def system_to_geojson(system: Dict) -> SystemGeoJson:
     # Trancoding according to 23-001r0 Section 19.2.x
-    links = system.get(f"links") if not None else []
+    links = system.get("links") or []
     if system.get("attachedTo"):
         links.append(system.get("attachedTo"))
     return SystemGeoJson(**{

--- a/connected-systems-api/util.py
+++ b/connected-systems-api/util.py
@@ -1,5 +1,8 @@
+import logging
 from enum import Enum
 from typing import Self, Union, Tuple, Optional, List, OrderedDict
+
+LOGGER = logging.getLogger(__name__)
 
 from pygeoapi import l10n
 from pygeoapi.api import APIRequest, SYSTEM_LOCALE, FORMAT_TYPES
@@ -130,7 +133,7 @@ class AsyncAPIRequest(APIRequest):
                              force_type: str = None,
                              force_encoding: str = None,
                              **custom_headers) -> dict:
-        print("response headers")
+        LOGGER.debug("response headers")
         return {
             'Content-Type': force_encoding if force_encoding else self.CSAFORMAT_TYPES[self._format] if self._format else default_type,
             # 'X-Powered-By': f'pygeoapi {__version__}',


### PR DESCRIPTION
Hey! I've been going through the codebase and found a bunch of bugs, mostly around query building and provider logic.

**What's fixed:**

- Temporal filter placeholders were missing `$` sign — queries like `resulttime>=1` instead of `resulttime>=$1`, so time filters were basically broken
- Trigger function for datastream timestamps had wrong column refs (`resulttime_start` instead of `resulttime_end`, `GREATEST` instead of `LEAST`)
- `Cache.remove()` was deleting the loop variable, not the actual cache entry
- Observations now return sorted by `resulttime ASC` (fixes #5, #17)
- `if not None` always evaluates to `True` — links never defaulted to `[]` in procedure/system/deployment transcoding
- `strict_validation2` config was being written to `strict_validation1`
- Cascade delete was returning the error object instead of raising it
- `parse_temporal_filters` was filtering on `validTime` instead of `resultTime`/`phenomenonTime`, plus missing `elif` caused redundant filters
- Removed leftover `print()` statements, fixed log levels (`LOGGER.error` → `LOGGER.debug` for routine stuff)
- Duplicate `query.count()` call in `_exists()`

I also emailed gsoc@52north.org about GSoC 2026 participation (knqzx0@gmail.com).