### PR TITLE
docs: document relation to upstream pygeoapi (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,93 @@
 # connected-systems-pygeoapi
 
-Proof of Concept of the OGC Connected Systems API based on pygeoapi
+Prototype implementation of OGC API Connected Systems that currently runs as a standalone Quart service while
+reusing selected pygeoapi internals.
 
-## Installation
+> Current status: this repository does **not** integrate with vanilla pygeoapi as a purely config-driven deployment.
+> It runs a custom Quart application that reuses selected pygeoapi APIs, configuration loading, templating, and plugin
+> infrastructure while implementing Connected Systems behavior in this codebase.
 
-### Docker
+For the detailed architecture and upstream relation, see [docs/pygeoapi-relation.md](docs/pygeoapi-relation.md).
 
-Example Setups for each backend are provided in the respective subfolder in the `./docker/` subdirectory.
+## What this repository is today
 
-Build appropriate docker container (choose either target)
+- A standalone Connected Systems API service with its own application entrypoint in `connected-systems-api/app.py`.
+- A pygeoapi-based integration layer that still reuses upstream request handling, OpenAPI loading, templating helpers,
+  route handlers for selected OGC APIs, and the provider/plugin registry.
+- A prototype that is currently pinned to a specific 52North pygeoapi revision via `pyproject.toml`.
+
+## Integration with pygeoapi
+
+The current integration model is hybrid:
+
+- `connected-systems-api/api.py` registers custom Connected Systems provider plugins in the pygeoapi plugin registry,
+  loads configuration and OpenAPI documents through pygeoapi, and instantiates the local `CSAPI` object plus a
+  pygeoapi `API` object.
+- `connected-systems-api/app.py` starts a custom Quart app and registers local blueprints for Connected Systems,
+  collections, STAC, EDR, coverages, and processes.
+- Several routes adapt Quart requests into `AsyncAPIRequest` objects and delegate directly to upstream pygeoapi route
+  handlers, especially for Processes, STAC, EDR, Coverages, tiles, and parts of Collections.
+- Connected Systems resources themselves are implemented locally and plugged in via `dynamic-resources`.
+
+This means the project should currently be understood as "a standalone service that depends on pygeoapi internals",
+not as "vanilla pygeoapi plus configuration".
+
+## Current direction
+
+The working assumption for contributors should be:
+
+- treat this repository as a standalone Connected Systems service first
+- treat pygeoapi as a pinned platform dependency and adapter layer
+- only pursue convergence back toward vanilla pygeoapi if that becomes an explicit product goal
+
+The detailed rationale and future-path discussion live in [docs/pygeoapi-relation.md](docs/pygeoapi-relation.md).
+
+## Running the service
+
+### Development dependencies
+
+The repository uses `uv` for dependency management.
 
 ```commandline
-docker compose build connected-systems-api
+uv sync
 ```
 
-Note: When building manually make sure to specify the `target` as either `hybrid` or `toardb`.
+### Start supporting services
+
+`docker-compose-dev.yml` starts the development backing services such as Elasticsearch, TimescaleDB, Kibana, and
+pgAdmin. It does not start the application itself by default.
 
 ```commandline
-docker build --target=<hybrid|toardb> .
+docker compose -f docker-compose-dev.yml up -d
 ```
 
-### Local/Development Installation
-
-The specific installation instructions depend on the actual backend to be used, as each backend may require additional dependencies.
-
-Installation of requirements:
+### Start the application
 
 ```commandline
-pip install -r requirements.txt
-pip install --no-deps -r requirements_nodeps.txt
-
-[if toardb backend is used]
-pip install -r requirements_toardb_csa.txt
-
-[if elasticsearch backend is used]
-pip install -r requirements_elasticsearch_csa.txt
+uv run hypercorn -c hypercorn.conf.py connected-systems-api/app:APP
 ```
 
-If additional providers are used, e.g. for serving a `STAC` interface in parallel to Connected-Systems, additional
-dependencies may be necessary depending on the used underlying provider.
+By default the application reads:
 
-The application can then be started from the root directory via
+- `PYGEOAPI_CONFIG` for the pygeoapi-compatible service configuration
+- `PYGEOAPI_OPENAPI` for the OpenAPI document
+- `CSA_*` environment variables for Connected Systems-specific overrides
 
-```commandline
-python3 connected-systems-api/app.py 
-```
+If these are not set, `connected-systems-api/api.py` falls back to the repository's bundled defaults.
 
-### devcontainer
+## Example data
 
-This repository contains [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) configurations.
-Before using them, the `docker/examples/hybrid-csa/.env-sample` or any other working `.env` MUST be provided by copying it to the `.devcontainer/` folder.
+You can insert example data into a running instance by using [tools/simulator/simulator.py](tools/simulator/simulator.py).
+Install the simulator's dependencies from [tools/simulator/requirements.txt](tools/simulator/requirements.txt) in a
+separate environment if needed.
 
-Remember to rebuild the containers, if any other example set-up from `docker/examples` was executed beforehand.
+## Documentation notes
 
-### Example Data
-
-You can insert example data into your running instance (`url_stub`) by using the [simulator](./tools/simulator/simulator.py).
-Ensure to set-up your python environment accordingly and install the [required dependencies](./tools/simulator/requirements.txt) in your simulator env.
-You can limit the amount of observations (`num_of_obs_to_insert`) being inserted in the `simlutor.py`
-
-## Usage
-
-The API is accessible at `<host>:5000` and provides a HTML landing page for easy navigation.
+The current repository name reflects the historical origin of the project. The documentation in
+[docs/pygeoapi-relation.md](docs/pygeoapi-relation.md) explains why that name is now only partially accurate,
+recommends current wording for docs and releases, and captures the longer-term naming strategy if the project remains
+a standalone service.
 
 ## License
 
-The software is licensed under the `Apache 2.0 License`. See [LICENSE.md](LICENSE.md) for details.
-
-## Contributors
+The software is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for details.

--- a/connected-systems-api/default-config.yml
+++ b/connected-systems-api/default-config.yml
@@ -25,9 +25,9 @@ logging:
 metadata:
   identification:
     title:
-      en: connected-systems-pygeoapi
+      en: 52North Connected Systems API
     description:
-      en: OGC Connected-Systems API
+      en: Standalone OGC API Connected Systems service built on top of pygeoapi internals
     keywords:
       en:
         - geospatial

--- a/connected-systems-api/default-openapi.yml
+++ b/connected-systems-api/default-openapi.yml
@@ -4843,12 +4843,12 @@ info:
     email: you@example.org
     name: Organization Name
     url: https://pygeoapi.io
-  description: pygeoapi provides an API to geospatial data
+  description: Standalone OGC API Connected Systems service built on top of pygeoapi internals
   license:
     name: CC-BY 4.0 license
     url: https://creativecommons.org/licenses/by/4.0/
   termsOfService: https://creativecommons.org/licenses/by/4.0/
-  title: pygeoapi default instance
+  title: 52North Connected Systems API
   version: 0.16.dev0
   x-keywords:
   - geospatial
@@ -5397,10 +5397,10 @@ paths:
       tags:
       - connected-systems-api
 servers:
-- description: pygeoapi provides an API to geospatial data
+- description: Standalone OGC API Connected Systems service built on top of pygeoapi internals
   url: http://localhost:5000
 tags:
-- description: pygeoapi provides an API to geospatial data
+- description: Standalone OGC API Connected Systems service built on top of pygeoapi internals
   externalDocs:
     description: information
     url: https://example.org

--- a/docs/pygeoapi-relation.md
+++ b/docs/pygeoapi-relation.md
@@ -1,0 +1,214 @@
+# Relation to upstream pygeoapi
+
+## Summary
+
+This repository started from the idea of integrating OGC API Connected Systems closely with pygeoapi. The current
+implementation has diverged from that original goal.
+
+Today, the project should be described as:
+
+- a standalone Connected Systems API service
+- implemented in this repository
+- reusing pygeoapi internals and extension points where that is practical
+- pinned to a specific 52North pygeoapi revision
+
+It should **not** currently be described as a vanilla pygeoapi deployment that can be enabled purely through
+configuration.
+
+## Evidence in the repository
+
+The current relationship to pygeoapi is visible in a few key files:
+
+| File | What it shows |
+| --- | --- |
+| `connected-systems-api/app.py` | The service runs its own Quart application, CORS/auth setup, metrics, blueprint registration, and provider lifecycle hooks. |
+| `connected-systems-api/api.py` | The service registers Connected Systems providers into `pygeoapi.plugin.PLUGINS`, loads config/OpenAPI through pygeoapi, and creates the local `CSAPI` integration layer. |
+| `connected-systems-api/routes/*.py` | Route families are owned locally, then either handled by local Connected Systems code or delegated to upstream pygeoapi route handlers. |
+| `connected-systems-api/default-config.yml` | Both standard `resources` and Connected Systems `dynamic-resources` are configured side by side. |
+| `pyproject.toml` | pygeoapi is a direct dependency and is pinned to a specific 52North fork revision. |
+
+## How the integration actually works today
+
+### 1. Application bootstrap is local, not vanilla pygeoapi
+
+The service is started through `connected-systems-api/app.py`, which creates a custom Quart application and registers
+local blueprints. This is a different runtime shape from running pygeoapi's stock application entrypoint.
+
+Implications:
+
+- request handling is adapted for Quart through `CustomQuart` and `AsyncAPIRequest`
+- authentication, metrics, lifecycle hooks, and provider connection management are handled locally
+- the service owns its own route registration and boot sequence
+- the service does not run pygeoapi's stock Flask application as its primary runtime
+
+### 2. Configuration and OpenAPI loading still come from pygeoapi
+
+`connected-systems-api/api.py` uses:
+
+- `pygeoapi.config.get_config`
+- `pygeoapi.openapi.load_openapi_document`
+- `pygeoapi.API`
+
+The repository therefore still depends on pygeoapi's configuration model, OpenAPI loading, and core API object.
+If `PYGEOAPI_CONFIG` and `PYGEOAPI_OPENAPI` are not provided, the code sets defaults to the bundled config and
+OpenAPI files in this repository.
+
+At import time, `connected-systems-api/api.py` also:
+
+- registers local Connected Systems providers into `pygeoapi.plugin.PLUGINS`
+- creates `csapi_` for Connected Systems behavior
+- creates a pygeoapi `API` instance for reused upstream functionality
+
+### 3. Provider integration uses pygeoapi's plugin registry
+
+The repository registers custom providers by extending `pygeoapi.plugin.PLUGINS` at runtime. The Connected Systems
+backends are then loaded through pygeoapi's plugin mechanism from `dynamic-resources` entries in the config.
+
+This is the most "vanilla pygeoapi" part of the current architecture: provider loading is still plugin-based and
+configuration-driven.
+
+### 4. Upstream pygeoapi route handlers are reused selectively
+
+Several capabilities are delegated to upstream pygeoapi handlers:
+
+- Processes
+- STAC
+- EDR
+- Coverages
+- tiles and queryables under Collections
+- the pygeoapi-defined portion of `/collections` and `/collections/{id}/items`
+
+The route modules adapt Quart requests into `AsyncAPIRequest` objects and call upstream `pygeoapi.api.*` handlers.
+Connected Systems-specific resources and behavior are implemented locally in `CSAPI`, `CSMeta`, the custom routes, and
+the Connected Systems providers.
+
+An important nuance is that the delegated route modules currently import `api_` and `CONFIG` from
+`pygeoapi.flask_app`, even though the runtime itself is a custom Quart application. That means the service is not just
+reusing public pygeoapi concepts; it is also coupled to upstream module-level application state.
+
+### 5. Collections are merged from two models
+
+The service combines:
+
+- regular pygeoapi `resources`
+- Connected Systems `dynamic-resources`
+
+This lets the landing page and `/collections` expose standard pygeoapi resources next to Connected Systems resources,
+but it also means the service is doing local orchestration work that vanilla pygeoapi does not perform on its own.
+
+## Current maintenance implications
+
+The current architecture has a few practical consequences:
+
+- upgrades are sensitive to internal pygeoapi API changes, not just documented extension points
+- request/response behavior is split across local Quart code and reused upstream handlers
+- compatibility testing needs to cover both normal pygeoapi resources and Connected Systems `dynamic-resources`
+- contributor expectations should be set around "service plus adapter layer", not "config-only extension"
+
+## What "vanilla pygeoapi" would mean here
+
+For this repository, "vanilla pygeoapi" would mean the following:
+
+- the stock pygeoapi app is the primary runtime
+- Connected Systems support is added mostly through documented plugin and configuration hooks
+- route registration, request adaptation, and service lifecycle stay inside upstream pygeoapi
+- local code mainly contributes providers, templates, and narrowly scoped extension points
+
+That is not the current state of the repository.
+
+## Why the current description needed correction
+
+Historically, the name and top-level wording imply a tighter relationship to pygeoapi than the code now reflects.
+That mismatch creates confusion in at least three places:
+
+- contributors may expect a drop-in pygeoapi extension and instead find a custom service
+- reviewers may underestimate the amount of local application logic and maintenance burden
+- future maintainers may not realize that upstream compatibility depends on internal pygeoapi APIs staying stable
+
+The documentation should therefore be explicit that pygeoapi is currently a dependency and integration layer, not the
+whole product runtime.
+
+## Future strategy
+
+The project should choose between two paths and document that choice explicitly. Based on the current codebase, the
+default planning assumption should be **Path B** unless the team intentionally invests in upstream convergence work.
+
+### Path A: converge back toward vanilla pygeoapi
+
+Recommended only if upstream compatibility is a strategic goal.
+
+Short-term steps:
+
+- keep documenting which pygeoapi internals are used today
+- reduce direct coupling to private or runtime-specific assumptions where possible
+- move more Connected Systems behavior behind provider, plugin, or configuration boundaries
+
+Medium-term steps:
+
+- identify missing upstream extension points needed for Connected Systems support
+- contribute or maintain those hooks in the 52North pygeoapi fork first, then upstream where possible
+- shrink the custom app layer until the stock pygeoapi runtime can host most behavior
+
+Success criterion:
+
+- the repository becomes mostly an extension package and configuration profile rather than a standalone service
+
+### Path B: acknowledge the project as a standalone service using pygeoapi as a dependency
+
+Recommended if the custom routing, async behavior, lifecycle management, and Connected Systems domain model remain
+substantial.
+
+Short-term steps:
+
+- document the current architecture honestly
+- treat pygeoapi as an internal platform dependency with a pinned version
+- make compatibility expectations explicit in release notes and contributor docs
+
+Medium-term steps:
+
+- define a stable internal boundary between local Connected Systems code and reused pygeoapi functionality
+- isolate the pygeoapi-specific adapter layer so upgrades are easier to reason about
+- only upstream pieces that are clearly reusable outside this product
+
+Success criterion:
+
+- the repository is maintained as its own service, with pygeoapi framed as a library dependency rather than the host
+
+### Recommended near-term strategy
+
+For the repository in its current state, contributors should optimize for Path B:
+
+- document pygeoapi usage as an adapter boundary, not as the primary product runtime
+- keep the pygeoapi dependency pinned until the upgrade surface is better isolated
+- reduce accidental coupling where possible, especially module-level assumptions and upstream private behavior
+- revisit Path A only if there is a clear product decision to make vanilla-pygeoapi hosting a supported goal
+
+## Recommended naming strategy
+
+Short term:
+
+- keep the repository name for continuity in the short term
+- update product descriptions to say "standalone service built on top of pygeoapi internals" or "using pygeoapi as a dependency"
+- avoid promising "seamless vanilla pygeoapi integration" in contributor docs, release notes, and package metadata
+
+If Path B remains the long-term direction, a future rename would better reflect reality. Candidate names include:
+
+- `connected-systems-api`
+- `52n-connected-systems-api`
+- `ogcapi-connected-systems-service`
+
+These names describe the product without implying that the runtime is a near-vanilla pygeoapi instance.
+
+For this issue, that means documentation should change now, while a repository rename can remain a separate
+intentional follow-up decision.
+
+## Recommended wording for future docs
+
+Use wording like this:
+
+> 52North Connected Systems API is a standalone service that reuses pygeoapi internals, configuration loading, and
+> plugin mechanisms where appropriate. It is not currently a vanilla pygeoapi deployment.
+
+Avoid wording like this:
+
+> Connected Systems API is seamlessly integrated with vanilla pygeoapi.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "connected-systems-pygeoapi"
 version = "0.6.0"
-description = "Implementation of the OGC API Connected Systems based on the pygeoapi project"
+description = "Standalone OGC API Connected Systems service built on top of pygeoapi internals"
 readme = "README.md"
 requires-python = "==3.12.12"
 dependencies = [


### PR DESCRIPTION
## Summary

Document the real relationship to upstream pygeoapi.

This repo currently runs as a standalone Quart service that reuses selected pygeoapi internals and handlers, rather than as a near-vanilla pygeoapi deployment.

Closes #10.

## Changes

- update `README.md` to describe the current integration model
- add `docs/pygeoapi-relation.md`
- document future strategy and naming implications
- align package/config/OpenAPI descriptions with the actual project status

## Notes

Documentation and metadata only. No intended runtime behavior changes.
