### PR TITLE
Improve handling for JSON format for Part 1 items

### DIFF
--- a/connected-systems-api/api.py
+++ b/connected-systems-api/api.py
@@ -16,7 +16,6 @@
 import os
 import pathlib
 from http import HTTPMethod
-from xmlrpc.client import boolean
 
 import jsonschema
 import orjson
@@ -266,38 +265,40 @@ class CSAPI(CSMeta):
 
         allowed_mimetypes = []
         default_mimetype: MimeType = None
-        json_fallback_format: MimeType = None
+        # Concrete encoding that a generic 'json'/'application/json' request falls
+        # back to for feature resources (set per entity below); None = no fallback.
+        json_fallback_format: str = None
         match collection:
             case EntityType.SYSTEMS:
                 handler = self.provider_part1.query_systems
                 params = SystemsParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_SMLJSON, MimeType.F_GEOJSON]]
                 default_mimetype = MimeType.F_SMLJSON
-                json_fallback_format = default_mimetype
+                json_fallback_format = F_SMLJSON
             case EntityType.DEPLOYMENTS:
                 handler = self.provider_part1.query_deployments
                 params = DeploymentsParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_SMLJSON, MimeType.F_GEOJSON]]
                 default_mimetype = MimeType.F_SMLJSON
-                json_fallback_format = default_mimetype
+                json_fallback_format = F_SMLJSON
             case EntityType.PROCEDURES:
                 handler = self.provider_part1.query_procedures
                 params = ProceduresParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_SMLJSON, MimeType.F_GEOJSON]]
                 default_mimetype = MimeType.F_SMLJSON
-                json_fallback_format = default_mimetype
+                json_fallback_format = F_SMLJSON
             case EntityType.SAMPLING_FEATURES:
                 handler = self.provider_part1.query_sampling_features
                 params = SamplingFeaturesParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_GEOJSON]]
                 default_mimetype = MimeType.F_GEOJSON
-                json_fallback_format = default_mimetype
+                json_fallback_format = F_GEOJSON
             case EntityType.PROPERTIES:
                 handler = self.provider_part1.query_properties
                 params = CSAParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_SMLJSON]]
                 default_mimetype = MimeType.F_SMLJSON
-                json_fallback_format = default_mimetype
+                json_fallback_format = F_SMLJSON
             case EntityType.DATASTREAMS:
                 handler = self.provider_part2.query_datastreams
                 params = DatastreamsParams()
@@ -351,12 +352,14 @@ class CSAPI(CSMeta):
             parameters = parse_query_parameters(params, request.params, self.base_url + "/" + request.path_info)
             parameters.format = request.format if request.format is not None else default_mimetype.value
 
-            # CSA (Part 1) spec does not specify plain application/json response encoding (just geojson or smljson) for Part 1 features. Use a fallback if application/json (or json) is requested, .
-            # If fallback for json is used make sure response header reflects the correct fallback Mime type
-            use_json_fallback_format: boolean = parameters.format in ("json", MimeType.F_JSON.value) and json_fallback_format is not None
-            if use_json_fallback_format:
-                parameters.format = json_fallback_format.value
-                headers["Content-Type"] = json_fallback_format.value
+            # 'json'/'application/json' is not a defined encoding for feature resources
+            # (OGC 23-001 Clause 19 defines only GeoJSON and SensorML-JSON). Fall back to
+            # the preferred concrete encoding and report its real media type so the
+            # Content-Type matches the body that is actually returned.
+            use_json_fallback = json_fallback_format and parameters.format in ("json", MimeType.F_JSON.value)
+            if use_json_fallback:
+                parameters.format = json_fallback_format
+                headers["Content-Type"] = request.CSAFORMAT_TYPES[json_fallback_format]
 
             data = await handler(parameters)
 

--- a/connected-systems-api/api.py
+++ b/connected-systems-api/api.py
@@ -352,10 +352,9 @@ class CSAPI(CSMeta):
             parameters = parse_query_parameters(params, request.params, self.base_url + "/" + request.path_info)
             parameters.format = request.format if request.format is not None else default_mimetype
 
-            # 'json'/'application/json' is not a defined encoding for feature resources
-            # (OGC 23-001 Clause 19 defines only GeoJSON and SensorML-JSON). Fall back to
-            # the preferred concrete encoding and report its real media type so the
-            # Content-Type matches the body that is actually returned.
+            # 'json'/'application/json' is not a explicitly defined encoding for CSA Part 1 objects
+            # fallback to preferred concrete encoding and report its real media type so the
+            # Content-Type response header matches the body that is actually returned.
             use_json_fallback = json_fallback_format and parameters.format in (F_JSON, MimeType.F_JSON.value)
             if use_json_fallback:
                 parameters.format = json_fallback_format

--- a/connected-systems-api/api.py
+++ b/connected-systems-api/api.py
@@ -16,6 +16,7 @@
 import os
 import pathlib
 from http import HTTPMethod
+from xmlrpc.client import boolean
 
 import jsonschema
 import orjson
@@ -265,32 +266,38 @@ class CSAPI(CSMeta):
 
         allowed_mimetypes = []
         default_mimetype: MimeType = None
+        json_fallback_format: MimeType = None
         match collection:
             case EntityType.SYSTEMS:
                 handler = self.provider_part1.query_systems
                 params = SystemsParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_SMLJSON, MimeType.F_GEOJSON]]
                 default_mimetype = MimeType.F_SMLJSON
+                json_fallback_format = default_mimetype
             case EntityType.DEPLOYMENTS:
                 handler = self.provider_part1.query_deployments
                 params = DeploymentsParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_SMLJSON, MimeType.F_GEOJSON]]
                 default_mimetype = MimeType.F_SMLJSON
+                json_fallback_format = default_mimetype
             case EntityType.PROCEDURES:
                 handler = self.provider_part1.query_procedures
                 params = ProceduresParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_SMLJSON, MimeType.F_GEOJSON]]
                 default_mimetype = MimeType.F_SMLJSON
+                json_fallback_format = default_mimetype
             case EntityType.SAMPLING_FEATURES:
                 handler = self.provider_part1.query_sampling_features
                 params = SamplingFeaturesParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_GEOJSON]]
                 default_mimetype = MimeType.F_GEOJSON
+                json_fallback_format = default_mimetype
             case EntityType.PROPERTIES:
                 handler = self.provider_part1.query_properties
                 params = CSAParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_SMLJSON]]
                 default_mimetype = MimeType.F_SMLJSON
+                json_fallback_format = default_mimetype
             case EntityType.DATASTREAMS:
                 handler = self.provider_part2.query_datastreams
                 params = DatastreamsParams()
@@ -343,6 +350,14 @@ class CSAPI(CSMeta):
         try:
             parameters = parse_query_parameters(params, request.params, self.base_url + "/" + request.path_info)
             parameters.format = request.format if request.format is not None else default_mimetype.value
+
+            # CSA (Part 1) spec does not specify plain application/json response encoding (just geojson or smljson) for Part 1 features. Use a fallback if application/json (or json) is requested, .
+            # If fallback for json is used make sure response header reflects the correct fallback Mime type
+            use_json_fallback_format: boolean = parameters.format in ("json", MimeType.F_JSON.value) and json_fallback_format is not None
+            if use_json_fallback_format:
+                parameters.format = json_fallback_format.value
+                headers["Content-Type"] = json_fallback_format.value
+
             data = await handler(parameters)
 
             return self._format_json_response(request, headers, data, collection)

--- a/connected-systems-api/api.py
+++ b/connected-systems-api/api.py
@@ -264,57 +264,57 @@ class CSAPI(CSMeta):
         """
 
         allowed_mimetypes = []
-        default_mimetype: MimeType = None
+        default_mimetype: str = None
         # Concrete encoding that a generic 'json'/'application/json' request falls
-        # back to for feature resources (set per entity below); None = no fallback.
+        # back to for feature resources (set per entity below)
         json_fallback_format: str = None
         match collection:
             case EntityType.SYSTEMS:
                 handler = self.provider_part1.query_systems
                 params = SystemsParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_SMLJSON, MimeType.F_GEOJSON]]
-                default_mimetype = MimeType.F_SMLJSON
-                json_fallback_format = F_SMLJSON
+                default_mimetype = F_SMLJSON
+                json_fallback_format = default_mimetype
             case EntityType.DEPLOYMENTS:
                 handler = self.provider_part1.query_deployments
                 params = DeploymentsParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_SMLJSON, MimeType.F_GEOJSON]]
-                default_mimetype = MimeType.F_SMLJSON
-                json_fallback_format = F_SMLJSON
+                default_mimetype = F_SMLJSON
+                json_fallback_format = default_mimetype
             case EntityType.PROCEDURES:
                 handler = self.provider_part1.query_procedures
                 params = ProceduresParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_SMLJSON, MimeType.F_GEOJSON]]
-                default_mimetype = MimeType.F_SMLJSON
-                json_fallback_format = F_SMLJSON
+                default_mimetype = F_SMLJSON
+                json_fallback_format = default_mimetype
             case EntityType.SAMPLING_FEATURES:
                 handler = self.provider_part1.query_sampling_features
                 params = SamplingFeaturesParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_GEOJSON]]
-                default_mimetype = MimeType.F_GEOJSON
-                json_fallback_format = F_GEOJSON
+                default_mimetype = F_GEOJSON
+                json_fallback_format = default_mimetype
             case EntityType.PROPERTIES:
                 handler = self.provider_part1.query_properties
                 params = CSAParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_SMLJSON]]
-                default_mimetype = MimeType.F_SMLJSON
-                json_fallback_format = F_SMLJSON
+                default_mimetype = F_SMLJSON
+                json_fallback_format = default_mimetype
             case EntityType.DATASTREAMS:
                 handler = self.provider_part2.query_datastreams
                 params = DatastreamsParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_JSON]]
-                default_mimetype = MimeType.F_JSON
+                default_mimetype = F_JSON
             case EntityType.DATASTREAMS_SCHEMA:
                 handler = self.provider_part2.query_datastreams
                 params = DatastreamsParams()
                 params.schema = True
                 allowed_mimetypes = [m.value for m in [MimeType.F_JSON]]
-                default_mimetype = MimeType.F_JSON
+                default_mimetype = F_JSON
             case EntityType.OBSERVATIONS:
                 handler = self.provider_part2.query_observations
                 params = ObservationsParams()
                 allowed_mimetypes = [m.value for m in [MimeType.F_HTML, MimeType.F_JSON, MimeType.F_OMJSON]]
-                default_mimetype = MimeType.F_JSON
+                default_mimetype = F_JSON
 
         # Check if mime_type is allowed
         if not request.is_valid(allowed_mimetypes):
@@ -325,7 +325,7 @@ class CSAPI(CSMeta):
                 'InvalidMimetype',
                 f"invalid mimetype supplied! expected {allowed_mimetypes} got '{request.format}'")
 
-        headers = request.get_response_headers(**self.api_headers, default_type=default_mimetype.value, force_type=request.format)
+        headers = request.get_response_headers(**self.api_headers, default_type=default_mimetype)
         collection = True
         # Expand parameters with additional information based on path
         if path is not None:
@@ -350,16 +350,17 @@ class CSAPI(CSMeta):
 
         try:
             parameters = parse_query_parameters(params, request.params, self.base_url + "/" + request.path_info)
-            parameters.format = request.format if request.format is not None else default_mimetype.value
+            parameters.format = request.format if request.format is not None else default_mimetype
 
             # 'json'/'application/json' is not a defined encoding for feature resources
             # (OGC 23-001 Clause 19 defines only GeoJSON and SensorML-JSON). Fall back to
             # the preferred concrete encoding and report its real media type so the
             # Content-Type matches the body that is actually returned.
-            use_json_fallback = json_fallback_format and parameters.format in ("json", MimeType.F_JSON.value)
+            use_json_fallback = json_fallback_format and parameters.format in (F_JSON, MimeType.F_JSON.value)
             if use_json_fallback:
                 parameters.format = json_fallback_format
-                headers["Content-Type"] = request.CSAFORMAT_TYPES[json_fallback_format]
+                # Override the Content-Type header to match the concrete encoding that is actually returned
+                headers["Content-Type"] = request.get_response_headers(force_type=json_fallback_format)["Content-Type"]
 
             data = await handler(parameters)
 

--- a/connected-systems-api/provider/part2/formats/om_json_scalar.py
+++ b/connected-systems-api/provider/part2/formats/om_json_scalar.py
@@ -9,19 +9,28 @@ from ..util import SchemaParser, Observation
 class OMJsonSchemaParser(SchemaParser):
 
     def decode(self, data: any) -> Observation:
-        return Observation(
+        obs = Observation(
             datastream_id=data["datastream"],
             resultTime=DateTime.fromisoformat(data["resultTime"]),
             result=orjson.dumps(data["result"]),
         )
+        #if not provided phenomenon time equals result time by default
+        obs.phenomenonTime = DateTime.fromisoformat(data["phenomenonTime"]) if "phenomenonTime" in data else obs.resultTime
+
+        return obs
 
     def encode(self, obs: asyncpg.Record) -> any:
         # TODO(specki): Check what is officially required here, e.g. are datastream@link or foi@link necessary?
 
         # unpack always returns tuple for consistency
-        return {
+        obs_json =  {
             "id": str(obs["uuid"]),
             "datastream@id": str(obs["datastream_id"]),
             "resultTime": obs["resulttime"],
             "result": orjson.loads(obs["result"])
         }
+
+        if obs["phenomenontime"] is not None:
+            obs_json["phenomenonTime"] = obs["phenomenontime"]
+
+        return obs_json

--- a/connected-systems-api/provider/part2/formats/om_json_scalar.py
+++ b/connected-systems-api/provider/part2/formats/om_json_scalar.py
@@ -12,7 +12,7 @@ class OMJsonSchemaParser(SchemaParser):
         return Observation(
             datastream_id=data["datastream"],
             resultTime=DateTime.fromisoformat(data["resultTime"]),
-            result=orjson.dumps(data["result"]),
+            result=orjson.dumps(data["result"]).decode("utf-8"),
         )
 
     def encode(self, obs: asyncpg.Record) -> any:

--- a/connected-systems-api/provider/part2/part2.py
+++ b/connected-systems-api/provider/part2/part2.py
@@ -109,7 +109,7 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
                                                                 resulttime TIMESTAMPTZ NOT NULL,
                                                                 phenomenontime TIMESTAMPTZ,
                                                                 datastream_id text NOT NULL,
-                                                                result BYTEA NOT NULL,
+                                                                result JSONB NOT NULL,
                                                                 sampling_feature_id text,
                                                                 procedure_link text,
                                                                 parameters text

--- a/connected-systems-api/provider/part2/part2.py
+++ b/connected-systems-api/provider/part2/part2.py
@@ -10,7 +10,7 @@ from elasticsearch.dsl import async_connections
 from pygeoapi.provider.base import ProviderGenericError, ProviderItemNotFoundError, ProviderInvalidQueryError
 
 from .formats.om_json_scalar import OMJsonSchemaParser
-from .util import TimescaleDbConfig, ObservationQuery, Observation
+from .util import TimescaleDbConfig, ObservationQuery, Observation, SORT_ORDER, ORDER_BY
 from .. import es_conn_part2
 from ..datastream import Datastream
 from ..definitions import *
@@ -420,6 +420,9 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
         q = ObservationQuery()
         q.with_limit(parameters.limit)
 
+        #default order by result time
+        q.with_sort(order=SORT_ORDER.ASCENDING, order_by= ORDER_BY.RESULTTIME)
+
         if parameters.id:
             q.with_id(parameters.id)
         if parameters.offset:
@@ -431,10 +434,15 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
         if parameters.datastream:
             q.with_datastream(parameters.datastream)
 
+        #only if filtered by phenomenon time (and no result time filter) order by phenomenon time
+        if parameters._phenomenonTime and not parameters._resultTime:
+            q.with_sort(order=SORT_ORDER.ASCENDING, order_by=ORDER_BY.PHENOMENONTIME)
+
         async with self._pool.acquire() as connection:
             LOGGER.debug("SELECT * FROM observations " + q.to_sql())
             LOGGER.debug(f"{q.parameters}")
-            return await connection.fetch("SELECT * FROM observations " + q.to_sql(), *q.parameters)
+            query = "SELECT * FROM observations " + q.to_sql()
+            return await connection.fetch(query, *q.parameters)
 
     async def _delete_observation(self, identifier: str):
         q = ObservationQuery()

--- a/connected-systems-api/provider/part2/part2.py
+++ b/connected-systems-api/provider/part2/part2.py
@@ -139,7 +139,7 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
                                    UPDATE datastreams SET
                                    resulttime_start=LEAST(resulttime_start, NEW.resulttime),
                                    resulttime_end=GREATEST(resulttime_start, NEW.resulttime),
-                                   phenomenontime_start=GREATEST(phenomenontime_start, NEW.phenomenontime),
+                                   phenomenontime_start=LEAST(phenomenontime_start, NEW.phenomenontime),
                                    phenomenontime_end=GREATEST(phenomenontime_start, NEW.phenomenontime)
                                    WHERE id=NEW.datastream_id;
                                    RETURN NULL;

--- a/connected-systems-api/provider/part2/part2.py
+++ b/connected-systems-api/provider/part2/part2.py
@@ -419,9 +419,7 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
     async def _get_observations(self, parameters: ObservationsParams) -> list:
         q = ObservationQuery()
         q.with_limit(parameters.limit)
-
-        #default order by result time
-        q.with_sort(order=SORT_ORDER.ASCENDING, order_by= ORDER_BY.RESULTTIME)
+        q.with_sort(order=SORT_ORDER.ASCENDING, order_by= ORDER_BY.PHENOMENONTIME) #always sorted by phenomenon time
 
         if parameters.id:
             q.with_id(parameters.id)
@@ -434,9 +432,6 @@ class ConnectedSystemsTimescaleDBProvider(ConnectedSystemsPart2Provider, Elastic
         if parameters.datastream:
             q.with_datastream(parameters.datastream)
 
-        #only if filtered by phenomenon time (and no result time filter) order by phenomenon time
-        if parameters._phenomenonTime and not parameters._resultTime:
-            q.with_sort(order=SORT_ORDER.ASCENDING, order_by=ORDER_BY.PHENOMENONTIME)
 
         async with self._pool.acquire() as connection:
             LOGGER.debug("SELECT * FROM observations " + q.to_sql())

--- a/connected-systems-api/provider/part2/util.py
+++ b/connected-systems-api/provider/part2/util.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import field
-from typing import Self
+from typing import Self, Dict, List, Optional
 
 from ..definitions import *
 
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 class Observation:
     datastream_id: str  # id of the associated datastream
     resultTime: DateTime
-    result: bytes  # raw result data
+    result: Dict[str, any]  # raw result data
 
     id: Optional[str] = None  # unique identifier
     sampling_feature_id: Optional[str] = None

--- a/connected-systems-api/provider/part2/util.py
+++ b/connected-systems-api/provider/part2/util.py
@@ -36,7 +36,15 @@ class TimescaleDbConfig:
 
     def connection_string(self) -> str:
         return f"postgres://{self.user}:{self.password}@{self.hostname}:{self.port}/{self.dbname}"
+    
 
+class SORT_ORDER(Enum):
+    DESCENDING = "DESC"
+    ASCENDING = "ASC"
+
+class ORDER_BY(Enum):
+    RESULTTIME = "resulttime"
+    PHENOMENONTIME = "phenomenontime"
 
 class SchemaParser:
     """
@@ -64,6 +72,8 @@ class ObservationQuery:
         self.parameters = []
         self.limit = 10
         self.offset = 0
+        self.order = "ASC"
+        self.order_by = "resulttime"
 
     def with_id(self, ids: List[str]) -> Self:
         return self._in("uuid", ids)
@@ -100,7 +110,21 @@ class ObservationQuery:
         if time[1] is not None:
             self.clauses.append(f"{key}<=${len(self.clauses) + 1}")
             self.parameters.append(time[1])
+
         return self
+    
+    def with_sort(self, order: SORT_ORDER, order_by: ORDER_BY):
+        if order == SORT_ORDER.ASCENDING:
+            self.order = "ASC"
+        else:
+            self.order = "DESC"
+        
+        if order_by == ORDER_BY.RESULTTIME:
+            self.order_by = "resulttime"
+        else:
+            self.order_by = "phenomenontime"
+
+        
 
     def to_sql(self, with_paging: bool = True) -> str:
         stub = ""
@@ -109,6 +133,9 @@ class ObservationQuery:
             # first clause
             stub = "WHERE "
             stub += " AND ".join(self.clauses)
+
+        if self.order and self.order_by:
+            stub += f" ORDER BY {self.order_by} {self.order}"
 
         if with_paging:
             stub += f" LIMIT {self.limit}"

--- a/connected-systems-api/util.py
+++ b/connected-systems-api/util.py
@@ -128,11 +128,10 @@ class AsyncAPIRequest(APIRequest):
     def get_response_headers(self, force_lang: l10n.Locale = None,
                              default_type: str = None,
                              force_type: str = None,
-                             force_encoding: str = None,
                              **custom_headers) -> dict:
         print("response headers")
         return {
-            'Content-Type': force_encoding if force_encoding else self.CSAFORMAT_TYPES[self._format] if self._format else default_type,
+            'Content-Type': force_type if force_type else self.CSAFORMAT_TYPES[self._format] if self._format else default_type,
             # 'X-Powered-By': f'pygeoapi {__version__}',
         }
 

--- a/connected-systems-api/util.py
+++ b/connected-systems-api/util.py
@@ -129,11 +129,19 @@ class AsyncAPIRequest(APIRequest):
                              default_type: str = None,
                              force_type: str = None,
                              **custom_headers) -> dict:
-        print("response headers")
-        return {
-            'Content-Type': force_type if force_type else self.CSAFORMAT_TYPES[self._format] if self._format else default_type,
+        
+        content_type = self.CSAFORMAT_TYPES[default_type] if default_type and default_type in self.CSAFORMAT_TYPES else None
+        if force_type and force_type in self.CSAFORMAT_TYPES:
+            content_type = self.CSAFORMAT_TYPES[force_type]
+        elif self._format and self._format in self.CSAFORMAT_TYPES:
+            content_type = self.CSAFORMAT_TYPES[self._format]
+
+        response_headers = {
+            'Content-Type': content_type,
             # 'X-Powered-By': f'pygeoapi {__version__}',
         }
+        print(f"response_headers: {response_headers}")
+        return response_headers
 
 
 def parse_request(func):

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -15,38 +15,40 @@ networks:
     external: false
 
 services:
-#  connected-systems-api:
-#    image: 52north/connected-systems-pygeoapi:local
-#    build:
-#      context: .
-#    environment:
-#      PYTHONUNBUFFERED: 1
-#      CSA_SERVER_BIND_HOST: localhost
-#      CSA_SERVER_BIND_PORT: 5000
-#      CSA_CORS_ALLOW_ORIGIN: "*"
-#      CSA_QUART_AUTH_BASIC_READ: "false"
-#      CSA_QUART_AUTH_BASIC_READWRITE: "false"
-#      CSA_DYNAMIC-RESOURCES_CSA-PART1_PROVIDER_HOST: es01
-#      CSA_DYNAMIC-RESOURCES_CSA-PART1_PROVIDER_PASSWORD: password
-#      CSA_DYNAMIC-RESOURCES_CSA-PART1_PROVIDER_USER: elastic
-#      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_ELASTIC_HOST: es01
-#      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_ELASTIC_PASSWORD: password
-#      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_ELASTIC_USER: elastic
-#      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_HOST: timescaledb
-#      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_PASSWORD: password
-#      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_USER: timescaledb
-#      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_PORT: 5432
-#    ports:
-#      - 5000:5000
-#    healthcheck:
-#      test: [ "CMD-SHELL", 'sh -c "wget -q -nv --spider http://127.0.0.1:5000/status || exit 1"' ]
-#      interval: 15s
-#      timeout: 30s
-#    depends_on:
-#      es01:
-#        condition: service_healthy
-#      timescaledb:
-#        condition: service_healthy
+  connected-systems-api:
+    image: csa_api
+    environment:
+      PYTHONUNBUFFERED: 1
+      CSA_SERVER_BIND_HOST: localhost
+      CSA_SERVER_BIND_PORT: 5000
+      CSA_CORS_ALLOW_ORIGIN: "*"
+      CSA_QUART_AUTH_BASIC_READ: "false"
+      CSA_QUART_AUTH_BASIC_READWRITE: "false"
+      CSA_DYNAMIC-RESOURCES_CSA-PART1_PROVIDER_HOST: es01
+      CSA_DYNAMIC-RESOURCES_CSA-PART1_PROVIDER_PASSWORD: password
+      CSA_DYNAMIC-RESOURCES_CSA-PART1_PROVIDER_USER: elastic
+      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_ELASTIC_HOST: es01
+      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_ELASTIC_PASSWORD: password
+      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_ELASTIC_USER: elastic
+      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_HOST: timescaledb
+      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_PASSWORD: password
+      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_USER: timescaledb
+      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_PORT: 5432
+    ports:
+      - 5000:5000
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'sh -c "wget -q -nv --spider http://127.0.0.1:5000/status || exit 1"',
+        ]
+      interval: 15s
+      timeout: 30s
+    depends_on:
+      es01:
+        condition: service_healthy
+      timescaledb:
+        condition: service_healthy
 
   timescaledb:
     image: timescale/timescaledb-ha:pg16
@@ -60,7 +62,7 @@ services:
     volumes:
       - postgresdata:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
+      test: ["CMD-SHELL", "pg_isready -d csa -U timescaledb"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -112,7 +114,7 @@ services:
         echo "All done!";
       '
     healthcheck:
-      test: [ "CMD-SHELL", "[ -f config/certs/es01/es01.crt ]" ]
+      test: ["CMD-SHELL", "[ -f config/certs/es01/es01.crt ]"]
       interval: 1s
       timeout: 5s
       retries: 120
@@ -197,6 +199,6 @@ services:
     environment:
       PGADMIN_DEFAULT_EMAIL: admin@example.io
       PGADMIN_DEFAULT_PASSWORD: admin
-      PGADMIN_CONFIG_SERVER_MODE: 'False'
+      PGADMIN_CONFIG_SERVER_MODE: "False"
     ports:
       - 5050:80

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -16,39 +16,38 @@ networks:
 
 services:
   connected-systems-api:
-    image: csa_api
-    environment:
-      PYTHONUNBUFFERED: 1
-      CSA_SERVER_BIND_HOST: localhost
-      CSA_SERVER_BIND_PORT: 5000
-      CSA_CORS_ALLOW_ORIGIN: "*"
-      CSA_QUART_AUTH_BASIC_READ: "false"
-      CSA_QUART_AUTH_BASIC_READWRITE: "false"
-      CSA_DYNAMIC-RESOURCES_CSA-PART1_PROVIDER_HOST: es01
-      CSA_DYNAMIC-RESOURCES_CSA-PART1_PROVIDER_PASSWORD: password
-      CSA_DYNAMIC-RESOURCES_CSA-PART1_PROVIDER_USER: elastic
-      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_ELASTIC_HOST: es01
-      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_ELASTIC_PASSWORD: password
-      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_ELASTIC_USER: elastic
-      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_HOST: timescaledb
-      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_PASSWORD: password
-      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_USER: timescaledb
-      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_PORT: 5432
-    ports:
-      - 5000:5000
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          'sh -c "wget -q -nv --spider http://127.0.0.1:5000/status || exit 1"',
-        ]
-      interval: 15s
-      timeout: 30s
-    depends_on:
-      es01:
-        condition: service_healthy
-      timescaledb:
-        condition: service_healthy
+  #  connected-systems-api:
+  #    image: 52north/connected-systems-pygeoapi:local
+  #    build:
+  #      context: .
+  #    environment:
+  #      PYTHONUNBUFFERED: 1
+  #      CSA_SERVER_BIND_HOST: localhost
+  #      CSA_SERVER_BIND_PORT: 5000
+  #      CSA_CORS_ALLOW_ORIGIN: "*"
+  #      CSA_QUART_AUTH_BASIC_READ: "false"
+  #      CSA_QUART_AUTH_BASIC_READWRITE: "false"
+  #      CSA_DYNAMIC-RESOURCES_CSA-PART1_PROVIDER_HOST: es01
+  #      CSA_DYNAMIC-RESOURCES_CSA-PART1_PROVIDER_PASSWORD: password
+  #      CSA_DYNAMIC-RESOURCES_CSA-PART1_PROVIDER_USER: elastic
+  #      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_ELASTIC_HOST: es01
+  #      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_ELASTIC_PASSWORD: password
+  #      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_ELASTIC_USER: elastic
+  #      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_HOST: timescaledb
+  #      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_PASSWORD: password
+  #      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_USER: timescaledb
+  #      CSA_DYNAMIC-RESOURCES_CSA-PART2_PROVIDER_TIMESCALE_PORT: 5432
+  #    ports:
+  #      - 5000:5000
+  #    healthcheck:
+  #      test: [ "CMD-SHELL", 'sh -c "wget -q -nv --spider http://127.0.0.1:5000/status || exit 1"' ]
+  #      interval: 15s
+  #      timeout: 30s
+  #    depends_on:
+  #      es01:
+  #        condition: service_healthy
+  #      timescaledb:
+  #        condition: service_healthy
 
   timescaledb:
     image: timescale/timescaledb-ha:pg16


### PR DESCRIPTION
Simple `application/json` encoding is not explicitly defined for CSA Part 1 objects (e.g `systems` or `subsystems`)  (only `application/geo+json` and `application/sml+json`).
Though,  `application/json` is often requested, e.g. the links in the HTML templates.
Currently. requesting `application/json` leads to server errors or (falsely) empty GeoJson collection responses.


- implemented fallback for `application/json`
  - fallback to default, `SMLJson` or `GeoJSON`
  - Content Type response header always reports the encoding that is actually used in the body
-  slightly improve handling of (requested) formats and mime types